### PR TITLE
Fix crash that can happen due to bug in cache creation

### DIFF
--- a/Circle/CircleIVarLayout.m
+++ b/Circle/CircleIVarLayout.m
@@ -240,7 +240,7 @@ static NSIndexSet *GetBlockStrongLayout(void *block)
     
     // If the layout cache doesn't exist, create it now. We'll add an entry to it.
     if(!gLayoutCache)
-        gLayoutCache = CFDictionaryCreateMutable(NULL, 0, NULL, NULL);
+        gLayoutCache = CFDictionaryCreateMutable(NULL, 0, NULL, &kCFTypeDictionaryValueCallBacks);
     
     // See if the layout already exists. We can't use the block isa as a key, since different
     // blocks can share an isa. Instead, we use the address of the destructor function as the


### PR DESCRIPTION
Hey!

Please advise if it's a bug. The cache between class layouts and block layouts is shared so we have kind of race condition who will create the cache now. In this case if you let block be queried first it will create a cache but won't state that it's a value cache therefore next time you'll try to use it you have a fair chance it will crash.
